### PR TITLE
Add hot reload dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,14 @@ This repository contains a minimal setup for the game backend and frontend.
 docker-compose up --build
 ```
 The backend will be available on `/api` and the frontend on port 80.
+
+## Development with hot reload
+
+Run the dev environment with:
+
+```
+docker-compose -f docker-compose.dev.yml up
+```
+
+The backend listens on port 3000 and reloads on changes. The Vite dev server is
+available on port 5173. An Nginx proxy still exposes everything on port 80.

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,8 @@
   "main": "dist/main.js",
   "scripts": {
     "start": "node dist/main.js",
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "dev": "ts-node-dev --respawn --transpile-only src/main.ts"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",
@@ -23,6 +24,7 @@
     "@types/jsonwebtoken": "^9.0.0",
     "@types/node": "^20.0.0",
     "@types/sequelize": "^4.28.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "ts-node-dev": "^2.0.0"
   }
 }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,60 @@
+version: '3'
+services:
+  db:
+    image: postgres:15
+    restart: always
+    environment:
+      POSTGRES_DB: game
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+
+  backend:
+    image: node:20-alpine
+    working_dir: /app
+    volumes:
+      - ./backend:/app
+      - backend_node_modules:/app/node_modules
+    environment:
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_USER: postgres
+      DB_PASSWORD: postgres
+      DB_NAME: game
+      ROUND_DURATION: ${ROUND_DURATION:-60}
+      COOLDOWN_DURATION: ${COOLDOWN_DURATION:-30}
+      JWT_SECRET: ${JWT_SECRET:-secret}
+      CHOKIDAR_USEPOLLING: "true"
+    command: sh -c "npm install && npm run dev"
+    depends_on:
+      - db
+    ports:
+      - "3000:3000"
+
+  frontend:
+    image: node:20-alpine
+    working_dir: /app
+    volumes:
+      - ./frontend:/app
+      - frontend_node_modules:/app/node_modules
+    environment:
+      CHOKIDAR_USEPOLLING: "true"
+    command: sh -c "npm install && npm run dev -- --host"
+    ports:
+      - "5173:5173"
+    depends_on:
+      - backend
+
+  proxy:
+    image: nginx:alpine
+    volumes:
+      - ./nginx.dev.conf:/etc/nginx/nginx.conf:ro
+    ports:
+      - "80:80"
+    depends_on:
+      - frontend
+      - backend
+
+volumes:
+  backend_node_modules:
+  frontend_node_modules:

--- a/nginx.dev.conf
+++ b/nginx.dev.conf
@@ -1,0 +1,17 @@
+worker_processes 1;
+
+events { worker_connections 1024; }
+
+http {
+  server {
+    listen 80;
+
+    location /api/ {
+      proxy_pass http://backend:3000/;
+    }
+
+    location / {
+      proxy_pass http://frontend:5173/;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `ts-node-dev` for backend watch mode
- add docker compose file for dev environment with live reload
- add matching nginx config for dev
- document how to run dev setup in README

## Testing
- `npm install --package-lock-only` *(fails: E403 Forbidden)*
- `docker compose -f docker-compose.dev.yml config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6862e1b089a88321aa0aa1d0b4693ad2